### PR TITLE
Fix nullable for dynamic choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ External libraries can provide their settings in YAML format with the same struc
 **Step 1**: Create a YAML file in the external library (e.g., `ndev_settings.yaml`):
 
 ```yaml
-ndevio_Reader:
+ndevio_reader:
   preferred_reader:
     default: bioio-ome-tiff
     dynamic_choices:
@@ -72,7 +72,7 @@ ndevio_Reader:
     tooltip: Whether to clear the viewer when selecting a new scene
     value: false
 
-ndevio_Export:
+ndevio_export:
   canvas_scale:
     default: 1.0
     max: 100.0

--- a/src/ndev_settings/_settings.py
+++ b/src/ndev_settings/_settings.py
@@ -290,11 +290,8 @@ class Settings:
             for group_name, group_settings in self._grouped_settings.items():
                 if setting_name in group_settings:
                     default = group_settings[setting_name].get("default")
-                    if default is not None:
-                        setattr(
-                            getattr(self, group_name), setting_name, default
-                        )
-                        group_settings[setting_name]["value"] = default
+                    setattr(getattr(self, group_name), setting_name, default)
+                    group_settings[setting_name]["value"] = default
                     self.save()
                     return
         else:

--- a/src/ndev_settings/_settings_widget.py
+++ b/src/ndev_settings/_settings_widget.py
@@ -51,11 +51,21 @@ class SettingsContainer(Container):
         if "dynamic_choices" in info:
             choices, fallback_message = self._get_dynamic_choices(info)
             choices_available = choices != [fallback_message]
-            current_value = init_value if init_value in choices else choices[0]
+            nullable = info.get("default") is None
+
+            current_value = (
+                init_value
+                if (init_value in choices or (nullable and init_value is None))
+                else choices[0]
+            )
 
             create_widget_args["value"] = current_value
             widget_options.update(
-                {"choices": choices, "enabled": choices_available}
+                {
+                    "choices": choices,
+                    "nullable": nullable,
+                    "enabled": choices_available,
+                }
             )
 
         # Pass options as a single parameter if we have any

--- a/tests/test_data/test_settings.yaml
+++ b/tests/test_data/test_settings.yaml
@@ -48,6 +48,13 @@ Group_A:
       provider: bioio.readers
     tooltip: Preferred reader to use when opening images
     value: bioio-ome-tiff
+  setting_dynamic_nullable:
+    default: null
+    dynamic_choices:
+      fallback_message: No readers found
+      provider: bioio.readers
+    tooltip: Nullable dynamic setting (None is valid)
+    value: null
 Group_B:
   setting_int:
     default: 50

--- a/tests/test_settings_widget.py
+++ b/tests/test_settings_widget.py
@@ -147,15 +147,15 @@ def test_grouping_functionality():
         key for key in container._widgets if key.startswith("Canvas.")
     ]
     reader_widgets = [
-        key for key in container._widgets if key.startswith("ndevio_Reader.")
+        key for key in container._widgets if key.startswith("ndevio_reader.")
     ]
 
     # Should have widgets from multiple groups
     if hasattr(container.settings, "Canvas"):
         assert len(canvas_widgets) > 0, "Should have Canvas widgets"
 
-    if hasattr(container.settings, "ndevio_Reader"):
-        assert len(reader_widgets) > 0, "Should have ndevio_Reader widgets"
+    if hasattr(container.settings, "ndevio_reader"):
+        assert len(reader_widgets) > 0, "Should have ndevio_reader widgets"
 
 
 def test_widget_container_with_custom_settings(test_settings_file):
@@ -241,3 +241,56 @@ def test_reset_to_defaults():
         settings.Group_A.setting_bool
         == settings._grouped_settings["Group_A"]["setting_bool"]["default"]
     )
+
+
+def test_nullable_dynamic_choices_includes_none():
+    """Test that dynamic choices with default=null include None as a valid option."""
+    container = SettingsContainer()
+
+    widget_key = "Group_A.setting_dynamic_nullable"
+    assert (
+        widget_key in container._widgets
+    ), f"Expected widget {widget_key} to exist"
+    widget = container._widgets[widget_key]
+
+    # None should be in the choices
+    assert (
+        None in widget.choices
+    ), f"None should be in choices for nullable dynamic setting, got {widget.choices}"
+
+    # The widget value should be None (matching the YAML value)
+    assert widget.value is None
+
+
+def test_non_nullable_dynamic_choices_excludes_none():
+    """Test that dynamic choices with non-null default do NOT include None."""
+    container = SettingsContainer()
+
+    widget_key = "Group_A.setting_dynamic"
+    assert (
+        widget_key in container._widgets
+    ), f"Expected widget {widget_key} to exist"
+    widget = container._widgets[widget_key]
+
+    # None should NOT be in the choices
+    assert (
+        None not in widget.choices
+    ), "None should not be in choices for non-nullable dynamic setting"
+
+
+def test_reset_nullable_dynamic_to_default():
+    """Test that resetting a nullable dynamic setting restores None."""
+    settings = get_settings()
+
+    # Verify initial default is None
+    assert settings.Group_A.setting_dynamic_nullable is None
+
+    # Change the setting
+    settings.Group_A.setting_dynamic_nullable = "some_reader"
+    assert settings.Group_A.setting_dynamic_nullable == "some_reader"
+
+    # Reset to defaults
+    settings.reset_to_default("setting_dynamic_nullable")
+
+    # Should be None again
+    assert settings.Group_A.setting_dynamic_nullable is None


### PR DESCRIPTION
# Description

Oops, I realized that nullable wasn't showing up in ndevio for the reader settings, but we want a nullable because we don't want a default. This fixes that and other instances by enabling the nullable kwarg for magicgui widgets 🤦 